### PR TITLE
Semester Reset Grace Period, JDK 12, Spring Boot 2.1.6, JDA 3.8.3_463, Maven SHA1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+jdk: openjdk12
 cache:
   directories:
   - "$HOME/.m2"
@@ -8,4 +9,4 @@ deploy:
     secure: Vrv0Io1Oy/Htv7E06jVYin5H9kD8p2B7VKctpaWOrWrlOpnuF7x2AGUcDgBdY3QB/eFOikPCu6HF6OTpFpbku7/iJdgM95SSMBZZAnIUN2+K0FIS1jlLTj5/2h+PIBYeJrQ3zI+icA3B7LebjtTFq9A+yBdLL6eNFGat/nQBxFahjUd68fxkRHPeA3wlHqffB2kuqxR3Xm2eZLgvmquJeGjE/J/MI7MAn65CLce06der/tZNdt4a9W2ywPyvGMPUMKXXde9O+GGRasVh4sjP+cHmzPpIQYKlc4VD7ngp89buTrqViNbE+XEHj3vE3NKYRKkNGRc7P5lpqhWnxGD46SnN2h+368bYtiEeUlg4efcrtS5ZfLhQu19kb1pPCROIF5DXSaAKFEoRr40pahIbPKx3XpMVUVW8e9pwpy16W2+886OfW7GpV8ZhDnwckMN4WTvabaXBkvHJVGkbtFgLJzweDZ4euh1r7pgdhJW2BDLrqblAIfk/UqUnG3TTzU08YeqhGRTTbnfIwfYDv4kHtQ+Udo6oaoYe4XI/2Q9KINQau3gMi1QKZPpiUUjWMtaub2lbOWHfhwXkfYLxi0KilqQMkEg+cKFDRpmgOZawTZO5LhPsfj/27B9chzfnSacZ4M1ZvWryQl7bQwhizfKugU6dCnumotv0vhLvMNX11+s=
   app: mitchtalmadge-uofu-cs-bot
   on:
-    tags: true
+    branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>com.mitchtalmadge</groupId>
     <artifactId>uofu-cs-bot</artifactId>
-    <version>6.1.2</version>
+    <version>${sha1}</version>
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>12</maven.compiler.source>
+        <maven.compiler.target>12</maven.compiler.target>
         <xchange.version>4.2.1</xchange.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.6.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>3.8.3_462</version>
+            <version>3.8.3_463</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/UofUCSBot.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/UofUCSBot.java
@@ -8,8 +8,6 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import javax.annotation.PostConstruct;
-
 @EnableScheduling
 @EnableAsync
 @ComponentScan(includeFilters = @ComponentScan.Filter(InheritedComponent.class))

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/event/EventDistributor.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/event/EventDistributor.java
@@ -4,17 +4,17 @@ import com.mitchtalmadge.uofu_cs_bot.event.listeners.EventListenerAbstract;
 import com.mitchtalmadge.uofu_cs_bot.service.discord.DiscordService;
 import net.dv8tion.jda.core.events.Event;
 import net.dv8tion.jda.core.hooks.EventListener;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 @Component
-public class EventDistributor {
+public class EventDistributor implements InitializingBean {
 
     private final DiscordService discordService;
 
@@ -38,8 +38,8 @@ public class EventDistributor {
         });
     }
 
-    @PostConstruct
-    private void init() {
+    @Override
+    public void afterPropertiesSet() throws Exception {
         discordService.getJDA().addEventListener((EventListener) this::onEvent);
     }
 

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/SpringProfileService.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/SpringProfileService.java
@@ -6,18 +6,18 @@
 
 package com.mitchtalmadge.uofu_cs_bot.service;
 
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @Scope(BeanDefinition.SCOPE_SINGLETON)
-public class SpringProfileService {
+public class SpringProfileService implements InitializingBean {
 
     @Value("${spring.profiles.active:production}")
     private String activeProfilesString;
@@ -47,8 +47,8 @@ public class SpringProfileService {
         }
     }
 
-    @PostConstruct
-    private void init() {
+    @Override
+    public void afterPropertiesSet() throws Exception {
         String[] springProfilesSplit = activeProfilesString.split(" ");
         activeProfiles = new ArrayList<>();
 

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/DiscordService.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/DiscordService.java
@@ -5,16 +5,16 @@ import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.JDABuilder;
 import net.dv8tion.jda.core.entities.Guild;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.security.auth.login.LoginException;
 
 @Service
-public class DiscordService {
+public class DiscordService implements InitializingBean, DisposableBean {
 
     @Value("${DISCORD_TOKEN}")
     private String discordToken;
@@ -37,8 +37,8 @@ public class DiscordService {
         this.logService = logService;
     }
 
-    @PostConstruct
-    private void init() throws LoginException {
+    @Override
+    public void afterPropertiesSet() throws Exception {
         try {
             jda = new JDABuilder(AccountType.BOT)
                     .setToken(discordToken)
@@ -54,8 +54,8 @@ public class DiscordService {
         }
     }
 
-    @PreDestroy
-    private void destroy() {
+    @Override
+    public void destroy() throws Exception {
         if (jda != null)
             jda.shutdown();
     }

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/SemesterResetService.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/SemesterResetService.java
@@ -9,12 +9,9 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.time.DayOfWeek;
 import java.time.Month;
 import java.time.MonthDay;
 import java.time.ZoneId;
-import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/SemesterResetService.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/SemesterResetService.java
@@ -9,9 +9,12 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
 import java.time.Month;
 import java.time.MonthDay;
 import java.time.ZoneId;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +30,7 @@ public class SemesterResetService {
      * Contains days on which the semester reset should be triggered.
      */
     private static final MonthDay[] SEMESTER_RESET_DAYS = {
-            MonthDay.of(Month.AUGUST, 10),
+            MonthDay.of(Month.AUGUST, 15),
             MonthDay.of(Month.JANUARY, 5)
     };
 
@@ -36,7 +39,10 @@ public class SemesterResetService {
      */
     private static final String SEMESTER_RESET_ANNOUNCEMENT = "@everyone\n" +
             "\n" +
-            "Welcome to a new semester! **All class-specific channels and roles have been reset.** Please update your nickname with any CS courses you are enrolled in this semester, and remember to invite your friends!\n" +
+            "Welcome to a new semester! **All class-specific channels have been reset.** " +
+            "If you haven't updated your nickname within the last month, it has been cleared. " +
+            "Please update your nickname with any CS courses you are enrolled in this semester, and " +
+            "remember to invite your friends!\n" +
             "\n" +
             "*Note: If you are a TA for any courses, just let a moderator know.*\n" +
             "*Invite Link:* **bit.ly/csattheu**";
@@ -79,19 +85,16 @@ public class SemesterResetService {
                 break;
             }
         }
-
-        // Don't reset if today is not a reset day.
-        if (!reset)
+        if (!reset) {
             return;
+        }
 
         logService.logInfo(getClass(), "!!!!!!!!!!!!!! Initiating Semester Reset !!!!!!!!!!!!!!");
 
         // Today is a reset day, begin resetting.
-        nicknameService.clearNicknames();
+        nicknameService.clearNicknamesOlderThanDays(30);
         deleteChannels();
-
         discordSynchronizationService.requestSynchronization();
-
         announceReset();
     }
 

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/features/club/ClubService.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/features/club/ClubService.java
@@ -1,9 +1,9 @@
 package com.mitchtalmadge.uofu_cs_bot.service.discord.features.club;
 
 import com.mitchtalmadge.uofu_cs_bot.domain.cs.Club;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
  * Keeps track of the enabled CS Clubs from the environment variables.
  */
 @Service
-public class ClubService {
+public class ClubService implements InitializingBean {
 
     /**
      * The environment variable that contains the list of enabled clubs.
@@ -30,8 +30,8 @@ public class ClubService {
      */
     private Set<Club> enabledClubs = new HashSet<>();
 
-    @PostConstruct
-    private void init() {
+    @Override
+    public void afterPropertiesSet() throws Exception {
         // Get the class number list from the environment variable.
         String clubNameList = System.getenv(CS_CLUBS_ENV_VAR);
         if (clubNameList == null) {

--- a/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/features/course/CourseService.java
+++ b/src/main/java/com/mitchtalmadge/uofu_cs_bot/service/discord/features/course/CourseService.java
@@ -2,10 +2,10 @@ package com.mitchtalmadge.uofu_cs_bot.service.discord.features.course;
 
 import com.mitchtalmadge.uofu_cs_bot.domain.cs.Course;
 import com.mitchtalmadge.uofu_cs_bot.service.LogService;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
  * Keeps track of the enabled CS Courses from the environment variables.
  */
 @Service
-public class CourseService {
+public class CourseService implements InitializingBean {
 
     /**
      * The environment variable that contains the list of enabled courses.
@@ -38,8 +38,8 @@ public class CourseService {
         this.logService = logService;
     }
 
-    @PostConstruct
-    private void init() {
+    @Override
+    public void afterPropertiesSet() throws Exception {
         // Get the course number list from the environment variable.
         String courseNumberList = System.getenv(CS_COURSES_ENV_VAR);
         if (courseNumberList == null) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=U of U CS Bot
-spring.main.web-environment=false
+spring.main.web-application-type=none
 logging.level.si.mazi.rescu.ResponseReader=ERROR

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=12


### PR DESCRIPTION
- Added 30 day "grace period" such that nicknames changed within this time period (from the current date) will not be cleared at the start of a new semester. This is to reduce annoyance with people who get eager and change their nicknames before the semester begins.
- Updated JDK to 12 
- Updated Spring Boot to 2.1.6
- Updated JDA to 3.8.3_463
- Maven versioning is now based on SHA1
- Travis deploy now occurs on all master commits.
- Heroku now uses JDK 12.